### PR TITLE
feat: 非同期 API と ストリーミング対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- 非同期 API: `aask` / `aask_batch` (`concurrency` で同時実行数を制御)
+- ストリーミング API: `ask_stream` と `StreamedResponse` (増分テキスト + 完了後に検証済みモデル)
+- 非同期・ストリーミングのテスト
+
+## [3.0.0]
+
+### Added
 - 検証失敗時の自己修復リトライ (エラー内容を添えて LLM に再生成を促す `max_retries`)
 - 構造化出力の強制: OpenAI Structured Outputs (`json_schema`) と Claude tool-use
 - `set_config` で `max_tokens` / `temperature` / `timeout` / `max_retries` を設定可能

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ LLMの出力をPydanticモデルで型安全に扱うためのPythonライブラ
 - バッチ処理に対応
 - **検証失敗時の自己修復リトライ** (エラー内容を添えて LLM に再生成を促す)
 - **構造化出力の強制** (OpenAI Structured Outputs / Claude tool-use)
+- **非同期 API** (`aask` / `aask_batch`) と **ストリーミング** (`ask_stream`)
 - `max_tokens` / `temperature` / `timeout` / `max_retries` を設定可能
 - シンプルなAPI
 - 環境変数から自動的にAPIキーを読み込み
@@ -254,6 +255,36 @@ set_config(
 
 - **GPT**: `response_format: json_schema` (Structured Outputs) でスキーマ準拠を促す
 - **Claude**: tool-use を強制し、スキーマに従った JSON を確実に取得する
+
+## 非同期 API
+
+```python
+import asyncio
+from dariko import aask, aask_batch
+
+async def main():
+    # 単発
+    person = await aask("...", output_model=Person)
+
+    # 複数プロンプトを並行実行 (concurrency で同時実行数を制限)
+    people = await aask_batch(["...", "..."], output_model=Person, concurrency=4)
+
+asyncio.run(main())
+```
+
+## ストリーミング
+
+```python
+from dariko import ask_stream
+
+stream = ask_stream("...", output_model=Person)
+for chunk in stream:        # 生成テキストを逐次受け取る
+    print(chunk, end="", flush=True)
+
+person = stream.result()    # 完了後に検証済みオブジェクト
+```
+
+> ストリーミングでは自己修復リトライは行わず、完了時に1回だけ検証します。
 
 ## ライセンス
 

--- a/dariko/__init__.py
+++ b/dariko/__init__.py
@@ -4,7 +4,15 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 from dariko.config import get_config, set_config
-from dariko.driver import ValidationError, ask, ask_batch
+from dariko.driver import (
+    StreamedResponse,
+    ValidationError,
+    aask,
+    aask_batch,
+    ask,
+    ask_batch,
+    ask_stream,
+)
 
 try:
     __version__ = _pkg_version("dariko")
@@ -12,10 +20,14 @@ except PackageNotFoundError:  # pragma: no cover - 未インストール (ソー
     __version__ = "0.0.0.dev0"
 
 __all__ = [
+    "StreamedResponse",
     "ValidationError",
     "__version__",
+    "aask",
+    "aask_batch",
     "ask",
     "ask_batch",
+    "ask_stream",
     "get_config",
     "set_config",
 ]

--- a/dariko/driver.py
+++ b/dariko/driver.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
-from typing import Any, Dict, List, Type
+from collections.abc import Iterator
+from typing import Any, Dict, List, Optional, Type
 
 from pydantic import BaseModel, TypeAdapter
 from pydantic import ValidationError as _PydanticValidationError
@@ -156,3 +158,98 @@ def ask_batch(prompts: List[str], *, output_model: Type[Any] | None = None) -> L
     """
     pyd_model = _resolve_model(output_model)
     return [_run(pyd_model, p) for p in prompts]
+
+
+# ─────────────────────────────────────────────────────────────
+# 非同期 API
+# ─────────────────────────────────────────────────────────────
+async def aask(prompt: str, *, output_model: Type[Any] | None = None) -> Any:
+    """
+    :func:`ask` の非同期版。ブロッキング I/O を別スレッドへ退避して実行する。
+    """
+    pyd_model = _resolve_model(output_model)
+    return await asyncio.to_thread(_run, pyd_model, prompt)
+
+
+async def aask_batch(
+    prompts: List[str],
+    *,
+    output_model: Type[Any] | None = None,
+    concurrency: Optional[int] = None,
+) -> List[Any]:
+    """
+    複数プロンプトを並行実行する :func:`ask_batch` の非同期版。
+
+    Args:
+        prompts: プロンプト列。
+        output_model: 出力 Pydantic モデル (省略時は型推論)。
+        concurrency: 同時実行数の上限。``None`` なら全件並行。
+    """
+    pyd_model = _resolve_model(output_model)
+    semaphore = asyncio.Semaphore(concurrency) if concurrency else None
+
+    async def _one(p: str) -> Any:
+        if semaphore is None:
+            return await asyncio.to_thread(_run, pyd_model, p)
+        async with semaphore:
+            return await asyncio.to_thread(_run, pyd_model, p)
+
+    return await asyncio.gather(*(_one(p) for p in prompts))
+
+
+# ─────────────────────────────────────────────────────────────
+# ストリーミング API
+# ─────────────────────────────────────────────────────────────
+class StreamedResponse:
+    """ストリーミング応答。テキスト増分を逐次 yield しつつ、完了後に検証済みモデルを返す。
+
+    使い方::
+
+        stream = ask_stream("...", output_model=Person)
+        for chunk in stream:      # 生成テキストを逐次受け取る
+            print(chunk, end="")
+        person = stream.result()  # 完了後に Pydantic 検証済みオブジェクト
+    """
+
+    def __init__(self, chunks: Iterator[str], pyd_model: Type[BaseModel]):
+        self._chunks = chunks
+        self._pyd_model = pyd_model
+        self._buffer: List[str] = []
+        self._result: Any = None
+        self._done = False
+
+    def __iter__(self) -> Iterator[str]:
+        for chunk in self._chunks:
+            self._buffer.append(chunk)
+            yield chunk
+        self._result = _parse_and_validate("".join(self._buffer), self._pyd_model)
+        self._done = True
+
+    @property
+    def text(self) -> str:
+        """これまでに受信したテキスト全体。"""
+        return "".join(self._buffer)
+
+    def result(self) -> Any:
+        """検証済みオブジェクトを返す (ストリームを最後まで消費後に呼ぶこと)。"""
+        if not self._done:
+            raise RuntimeError("ストリームを最後まで消費してから result() を呼んでください")
+        return self._result
+
+
+def ask_stream(prompt: str, *, output_model: Type[Any] | None = None) -> StreamedResponse:
+    """
+    プロンプトをストリーミング実行し、:class:`StreamedResponse` を返す。
+
+    増分テキストを逐次受け取りつつ、完了後に ``result()`` で検証済みモデルを得る。
+    ストリーミングでは自己修復リトライは行わない (検証は完了時に1回)。
+    """
+    pyd_model = _resolve_model(output_model)
+    llm = _get_llm_instance()
+    schema = pyd_model.model_json_schema()
+    messages: List[Dict[str, str]] = [
+        {"role": "system", "content": f"次の JSON Schema に厳密に従い、JSON のみを返してください:\n{schema}"},
+        {"role": "user", "content": prompt},
+    ]
+    chunks = llm.call_stream(messages, response_schema=schema)
+    return StreamedResponse(chunks, pyd_model)

--- a/dariko/models/claude.py
+++ b/dariko/models/claude.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Iterator
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -18,16 +19,19 @@ class Claude(LLM):
         super().__init__(model_name=model_name, llm_key=llm_key, **kwargs)
         self.api_url = "https://api.anthropic.com/v1/messages"
 
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "x-api-key": self.llm_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+
     def call(self, messages: List[Dict[str, str]], *, response_schema: Optional[Dict[str, Any]] = None) -> str:
         """Claude API を呼び出して応答テキスト (JSON 文字列) を返す。"""
         if not self.llm_key:
             raise ValueError("APIキーが必要です")
 
-        headers = {
-            "x-api-key": self.llm_key,
-            "anthropic-version": "2023-06-01",
-            "content-type": "application/json",
-        }
+        headers = self._headers()
         prompt = self._format_messages(messages)
         payload: Dict[str, Any] = {
             "model": self.model_name,
@@ -49,6 +53,40 @@ class Claude(LLM):
         resp = requests.post(self.api_url, headers=headers, json=payload, timeout=self.timeout)
         resp.raise_for_status()
         return self._extract_content(resp.json())
+
+    def call_stream(
+        self, messages: List[Dict[str, str]], *, response_schema: Optional[Dict[str, Any]] = None
+    ) -> Iterator[str]:
+        """Claude API を SSE で呼び出し、text の増分を逐次 yield する。
+
+        ストリーミング時は tool-use を使わず、テキスト (JSON 文字列) を逐次受け取る。
+        """
+        if not self.llm_key:
+            raise ValueError("APIキーが必要です")
+
+        prompt = self._format_messages(messages)
+        payload: Dict[str, Any] = {
+            "model": self.model_name,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": True,
+        }
+        with requests.post(
+            self.api_url, headers=self._headers(), json=payload, timeout=self.timeout, stream=True
+        ) as r:
+            r.raise_for_status()
+            for raw in r.iter_lines():
+                if not raw:
+                    continue
+                line = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+                if not line.startswith("data: "):
+                    continue
+                event = json.loads(line[len("data: ") :])
+                if event.get("type") == "content_block_delta":
+                    delta = event.get("delta", {})
+                    if delta.get("type") == "text_delta" and delta.get("text"):
+                        yield delta["text"]
 
     @staticmethod
     def _extract_content(body: Dict[str, Any]) -> str:

--- a/dariko/models/gpt.py
+++ b/dariko/models/gpt.py
@@ -1,3 +1,5 @@
+import json
+from collections.abc import Iterator
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -17,40 +19,71 @@ class GPT(LLM):
         super().__init__(model_name=model_name, llm_key=llm_key, **kwargs)
         self.api_url = "https://api.openai.com/v1/chat/completions"
 
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.llm_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _payload(
+        self, messages: List[Dict[str, str]], response_schema: Optional[Dict[str, Any]], stream: bool
+    ) -> Dict[str, Any]:
+        if response_schema is not None:
+            response_format: Dict[str, Any] = {
+                "type": "json_schema",
+                "json_schema": {"name": "dariko_output", "schema": response_schema, "strict": False},
+            }
+        else:
+            response_format = {"type": "json_object"}
+        return {
+            "model": self.model_name,
+            "messages": messages,
+            "response_format": response_format,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "stream": stream,
+        }
+
     def call(self, messages: List[Dict[str, str]], *, response_schema: Optional[Dict[str, Any]] = None) -> str:
         """OpenAI API を呼び出して応答テキストを返す。"""
         if not self.llm_key:
             raise ValueError("API key is required for OpenAI models")
 
-        if response_schema is not None:
-            response_format = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "dariko_output",
-                    "schema": response_schema,
-                    "strict": False,
-                },
-            }
-        else:
-            response_format = {"type": "json_object"}
-
         r = requests.post(
             self.api_url,
-            headers={
-                "Authorization": f"Bearer {self.llm_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": self.model_name,
-                "messages": messages,
-                "response_format": response_format,
-                "max_tokens": self.max_tokens,
-                "temperature": self.temperature,
-            },
+            headers=self._headers(),
+            json=self._payload(messages, response_schema, stream=False),
             timeout=self.timeout,
         )
-
         if r.status_code != 200:
             raise RuntimeError(f"OpenAI API call failed: {r.text}")
-
         return r.json()["choices"][0]["message"]["content"]
+
+    def call_stream(
+        self, messages: List[Dict[str, str]], *, response_schema: Optional[Dict[str, Any]] = None
+    ) -> Iterator[str]:
+        """OpenAI API を SSE で呼び出し、content の増分を逐次 yield する。"""
+        if not self.llm_key:
+            raise ValueError("API key is required for OpenAI models")
+
+        with requests.post(
+            self.api_url,
+            headers=self._headers(),
+            json=self._payload(messages, response_schema, stream=True),
+            timeout=self.timeout,
+            stream=True,
+        ) as r:
+            if r.status_code != 200:
+                raise RuntimeError(f"OpenAI API call failed: {r.text}")
+            for raw in r.iter_lines():
+                if not raw:
+                    continue
+                line = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+                if not line.startswith("data: "):
+                    continue
+                data = line[len("data: ") :]
+                if data == "[DONE]":
+                    break
+                delta = json.loads(data)["choices"][0]["delta"].get("content")
+                if delta:
+                    yield delta

--- a/dariko/models/llm.py
+++ b/dariko/models/llm.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from typing import Any, Dict, List, Optional
 
 
@@ -34,6 +35,15 @@ class LLM(ABC):
             response_schema: 出力を強制する Pydantic JSON Schema (任意)。
         """
         ...
+
+    def call_stream(
+        self, messages: List[Dict[str, str]], *, response_schema: Optional[Dict[str, Any]] = None
+    ) -> Iterator[str]:
+        """応答テキストを増分 (トークン) で逐次 yield する。
+
+        既定では未対応。ストリーミングをサポートするサブクラスが上書きする。
+        """
+        raise NotImplementedError(f"{type(self).__name__} はストリーミングに未対応です")
 
     @classmethod
     def configure(cls, model_name: str, llm_key: Optional[str] = None, **kwargs: Any) -> "LLM":

--- a/tests/test_core/test_async.py
+++ b/tests/test_core/test_async.py
@@ -1,0 +1,24 @@
+import asyncio
+from unittest.mock import patch
+
+from dariko import aask, aask_batch, set_config
+from tests.conftest import Person, mock_gpt_response
+
+
+@patch("dariko.models.gpt.requests.post", side_effect=mock_gpt_response)
+def test_aask(mock_post):
+    """aask が検証済みオブジェクトを返す。"""
+    set_config(model="gpt-4o-mini", llm_key="test_key")
+    result = asyncio.run(aask("test", output_model=Person))
+    assert isinstance(result, Person)
+    assert result.dummy is True
+
+
+@patch("dariko.models.gpt.requests.post", side_effect=mock_gpt_response)
+def test_aask_batch_concurrent(mock_post):
+    """aask_batch が複数プロンプトを処理する。"""
+    set_config(model="gpt-4o-mini", llm_key="test_key")
+    prompts = ["a", "b", "c"]
+    results = asyncio.run(aask_batch(prompts, output_model=Person, concurrency=2))
+    assert len(results) == 3
+    assert all(isinstance(r, Person) and r.dummy is True for r in results)

--- a/tests/test_core/test_stream.py
+++ b/tests/test_core/test_stream.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch
+
+import pytest
+
+from dariko import ask_stream, set_config
+from tests.conftest import Person
+
+
+class _StreamResp:
+    """requests.post(..., stream=True) の戻り値を模した SSE レスポンス。"""
+
+    def __init__(self, lines, status_code=200):
+        self._lines = lines
+        self.status_code = status_code
+        self.text = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def iter_lines(self):
+        yield from self._lines
+
+    def raise_for_status(self):
+        pass
+
+
+def _gpt_sse(parts):
+    """content 増分の列を OpenAI SSE 行 (bytes) に変換する。"""
+    lines = []
+    for p in parts:
+        body = '{"choices":[{"delta":{"content":%s}}]}' % _json_str(p)
+        lines.append(("data: " + body).encode("utf-8"))
+    lines.append(b"data: [DONE]")
+    return lines
+
+
+def _json_str(s):
+    import json
+
+    return json.dumps(s)
+
+
+def test_ask_stream_yields_and_validates():
+    """増分テキストを逐次受け取り、完了後に検証済みオブジェクトを返す。"""
+    set_config(model="gpt-4o-mini", llm_key="test_key")
+    parts = ['{"name": "test", ', '"age": 20, ', '"dummy": true}']
+
+    with patch("dariko.models.gpt.requests.post", return_value=_StreamResp(_gpt_sse(parts))):
+        stream = ask_stream("test", output_model=Person)
+        received = list(stream)  # ストリームを消費
+        result = stream.result()
+
+    assert "".join(received) == "".join(parts)
+    assert isinstance(result, Person)
+    assert result.dummy is True
+
+
+def test_result_before_consume_raises():
+    """消費前に result() を呼ぶとエラー。"""
+    set_config(model="gpt-4o-mini", llm_key="test_key")
+    sse = _gpt_sse(['{"name":"x","age":1,"dummy":false}'])
+    with patch("dariko.models.gpt.requests.post", return_value=_StreamResp(sse)):
+        stream = ask_stream("test", output_model=Person)
+        with pytest.raises(RuntimeError):
+            stream.result()


### PR DESCRIPTION
## Summary
- 非同期 API `aask` / `aask_batch` を追加（`asyncio.to_thread` ベース、新依存なし）
- ストリーミング API `ask_stream` / `StreamedResponse` を追加（GPT / Claude）

## 変更内容
- **非同期**: `aask`（単発）、`aask_batch`（並行実行、`concurrency` で同時実行数制御）。requests は I/O 中に GIL を解放するため実効並列。httpx 等の追加依存なし
- **ストリーミング**: `ask_stream` が SSE で増分テキストを逐次 yield、完了後 `result()` で検証済みモデルを返す。GPT は content delta、Claude は text_delta を解析。リトライは行わず完了時に1回検証
- LLM 基底に `call_stream` フックを追加（未対応モデルは `NotImplementedError`）
- README / CHANGELOG 更新

## 検証
- `python -m pytest` → 14 passed, 1 skipped
- `import dariko` で torch 未ロードを維持
- ruff（F/E/W/I/B）パス

破壊的変更なし → semantic-release はマイナー（v3.1.0）想定。