### PR TITLE
feat: 部分オブジェクトのストリーミングと list[Model] 出力

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- 部分オブジェクトのストリーミング: `StreamedResponse.partials()` (全フィールド Optional の部分モデルを逐次 yield)
+- `list[Model]` 出力: `output_model=list[Person]` でリストとして検証
+- 部分 JSON パーサ (`dariko.partial`) とテスト
+
+## [3.1.0]
+
+### Added
 - 非同期 API: `aask` / `aask_batch` (`concurrency` で同時実行数を制御)
 - ストリーミング API: `ask_stream` と `StreamedResponse` (増分テキスト + 完了後に検証済みモデル)
 - 非同期・ストリーミングのテスト

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ LLMの出力をPydanticモデルで型安全に扱うためのPythonライブラ
 - **検証失敗時の自己修復リトライ** (エラー内容を添えて LLM に再生成を促す)
 - **構造化出力の強制** (OpenAI Structured Outputs / Claude tool-use)
 - **非同期 API** (`aask` / `aask_batch`) と **ストリーミング** (`ask_stream`)
+- **部分オブジェクトのストリーミング** (`partials()`) — 埋まりかけのモデルを逐次取得
+- **`list[Model]` 出力** (`output_model=list[Person]`) でリスト検証
 - `max_tokens` / `temperature` / `timeout` / `max_retries` を設定可能
 - シンプルなAPI
 - 環境変数から自動的にAPIキーを読み込み
@@ -284,7 +286,26 @@ for chunk in stream:        # 生成テキストを逐次受け取る
 person = stream.result()    # 完了後に検証済みオブジェクト
 ```
 
+### 部分オブジェクトのストリーミング
+
+埋まりかけのモデル (全フィールド Optional) を逐次受け取れます。UI のプログレッシブ表示に便利です。
+
+```python
+stream = ask_stream("...", output_model=Person)
+for partial in stream.partials():
+    print(partial)   # name だけ -> name+age -> 全部、と段階的に埋まる
+
+person = stream.result()
+```
+
 > ストリーミングでは自己修復リトライは行わず、完了時に1回だけ検証します。
+
+## リスト出力
+
+```python
+people = ask("3人分の人物を返して", output_model=list[Person])
+# -> list[Person] として検証される
+```
 
 ## ライセンス
 

--- a/dariko/driver.py
+++ b/dariko/driver.py
@@ -13,6 +13,7 @@ from .config import get_config, get_llm_key, get_model
 from .exceptions import ValidationError
 from .model_utils import get_pydantic_model, infer_output_model
 from .models.llm import LLM
+from .partial import build_partial_model, parse_partial_json
 
 
 # モデル名のプレフィックス -> 対応する LLM クラスを返す関数のマッピング。
@@ -46,11 +47,14 @@ MODEL_MAPPING: Dict[str, Any] = {
 # ─────────────────────────────────────────────────────────────
 
 
-def _resolve_model(output_model: Type[Any] | None) -> Type[BaseModel]:
+def _resolve_model(output_model: Type[Any] | None) -> tuple[Type[BaseModel], bool]:
     """
     output_model が None の場合は呼び出しフレームから推論し、
-    最終的に Pydantic Model 型を返す。
+    ``(Pydantic Model 型, リストかどうか)`` を返す。
+
+    ``output_model=list[Person]`` のように指定された場合は出力をリストとして検証する。
     """
+    is_list = output_model is not None and getattr(output_model, "__origin__", None) is list
     if output_model is None:
         caller_frame = inspect.currentframe().f_back
         model = infer_output_model(caller_frame)
@@ -58,7 +62,7 @@ def _resolve_model(output_model: Type[Any] | None) -> Type[BaseModel]:
             raise TypeError("型アノテーションが取得できませんでした。output_model を指定してください。")
     else:
         model = output_model
-    return get_pydantic_model(model)  # 型チェックも兼ねる
+    return get_pydantic_model(model), is_list  # 型チェックも兼ねる
 
 
 def _get_llm_instance() -> LLM:
@@ -82,14 +86,15 @@ def _get_llm_instance() -> LLM:
     raise ValueError(f"Unsupported model: {model_name}")
 
 
-def _parse_and_validate(raw_json: str, pyd_model: Type[BaseModel]) -> BaseModel:
+def _parse_and_validate(raw_json: str, pyd_model: Type[BaseModel], *, is_list: bool = False) -> Any:
     """
     LLM 出力(JSON文字列)を parse & Pydantic 検証。
-    成功すれば Pydantic モデルのインスタンスを返す。
+    ``is_list`` が真なら ``list[pyd_model]`` として検証する。
     """
+    target: Any = List[pyd_model] if is_list else pyd_model
     try:
         data = json.loads(raw_json)
-        return TypeAdapter(pyd_model).validate_python(data)
+        return TypeAdapter(target).validate_python(data)
     except json.JSONDecodeError as e:
         raise ValidationError(
             _PydanticValidationError.from_exception_data(
@@ -101,7 +106,7 @@ def _parse_and_validate(raw_json: str, pyd_model: Type[BaseModel]) -> BaseModel:
         raise ValidationError(e) from None
 
 
-def _run(pyd_model: Type[BaseModel], prompt: str) -> Any:
+def _run(pyd_model: Type[BaseModel], prompt: str, *, is_list: bool = False) -> Any:
     """
     1 プロンプトを実行する。検証に失敗した場合はエラー内容を添えて
     最大 ``max_retries`` 回まで LLM に再生成を促す (自己修復)。
@@ -109,17 +114,18 @@ def _run(pyd_model: Type[BaseModel], prompt: str) -> Any:
     cfg = get_config()
     llm = _get_llm_instance()
     schema = pyd_model.model_json_schema()
+    request_schema = {"type": "array", "items": schema} if is_list else schema
 
     messages: List[Dict[str, str]] = [
-        {"role": "system", "content": f"次の JSON Schema に厳密に従い、JSON のみを返してください:\n{schema}"},
+        {"role": "system", "content": f"次の JSON Schema に厳密に従い、JSON のみを返してください:\n{request_schema}"},
         {"role": "user", "content": prompt},
     ]
 
     last_error: ValidationError | None = None
     for _ in range(cfg.max_retries + 1):
-        raw = llm.call(messages, response_schema=schema)
+        raw = llm.call(messages, response_schema=request_schema)
         try:
-            return _parse_and_validate(raw, pyd_model)
+            return _parse_and_validate(raw, pyd_model, is_list=is_list)
         except ValidationError as e:
             last_error = e
             # 直前の出力とエラーを会話に追加し、修正版を要求する
@@ -147,17 +153,18 @@ def ask(prompt: str, *, output_model: Type[Any] | None = None) -> Any:
 
     検証に失敗した場合は ``set_config(max_retries=...)`` の回数だけ
     LLM へ再生成を促してから ``ValidationError`` を送出する。
+    ``output_model=list[Model]`` を指定すると出力をリストとして検証する。
     """
-    pyd_model = _resolve_model(output_model)
-    return _run(pyd_model, prompt)
+    pyd_model, is_list = _resolve_model(output_model)
+    return _run(pyd_model, prompt, is_list=is_list)
 
 
 def ask_batch(prompts: List[str], *, output_model: Type[Any] | None = None) -> List[Any]:
     """
     複数プロンプトをバッチ処理し、検証済みオブジェクトをリストで返す。
     """
-    pyd_model = _resolve_model(output_model)
-    return [_run(pyd_model, p) for p in prompts]
+    pyd_model, is_list = _resolve_model(output_model)
+    return [_run(pyd_model, p, is_list=is_list) for p in prompts]
 
 
 # ─────────────────────────────────────────────────────────────
@@ -167,8 +174,8 @@ async def aask(prompt: str, *, output_model: Type[Any] | None = None) -> Any:
     """
     :func:`ask` の非同期版。ブロッキング I/O を別スレッドへ退避して実行する。
     """
-    pyd_model = _resolve_model(output_model)
-    return await asyncio.to_thread(_run, pyd_model, prompt)
+    pyd_model, is_list = _resolve_model(output_model)
+    return await asyncio.to_thread(lambda: _run(pyd_model, prompt, is_list=is_list))
 
 
 async def aask_batch(
@@ -185,14 +192,14 @@ async def aask_batch(
         output_model: 出力 Pydantic モデル (省略時は型推論)。
         concurrency: 同時実行数の上限。``None`` なら全件並行。
     """
-    pyd_model = _resolve_model(output_model)
+    pyd_model, is_list = _resolve_model(output_model)
     semaphore = asyncio.Semaphore(concurrency) if concurrency else None
 
     async def _one(p: str) -> Any:
         if semaphore is None:
-            return await asyncio.to_thread(_run, pyd_model, p)
+            return await asyncio.to_thread(lambda: _run(pyd_model, p, is_list=is_list))
         async with semaphore:
-            return await asyncio.to_thread(_run, pyd_model, p)
+            return await asyncio.to_thread(lambda: _run(pyd_model, p, is_list=is_list))
 
     return await asyncio.gather(*(_one(p) for p in prompts))
 
@@ -202,6 +209,9 @@ async def aask_batch(
 # ─────────────────────────────────────────────────────────────
 class StreamedResponse:
     """ストリーミング応答。テキスト増分を逐次 yield しつつ、完了後に検証済みモデルを返す。
+
+    テキスト増分が欲しい場合は ``for chunk in stream``、部分オブジェクトが
+    欲しい場合は ``for partial in stream.partials()`` を使う (どちらか一方のみ消費可能)。
 
     使い方::
 
@@ -225,6 +235,31 @@ class StreamedResponse:
         self._result = _parse_and_validate("".join(self._buffer), self._pyd_model)
         self._done = True
 
+    def partials(self) -> Iterator[Any]:
+        """部分的に埋まったモデル (全フィールド Optional) を逐次 yield する。
+
+        新しいチャンクを受け取るたびに、これまでの JSON を可能な範囲で
+        パースし、前回と異なれば部分モデルを yield する。完了後は
+        ``result()`` で完全な検証済みモデルを取得できる。
+        """
+        partial_cls = build_partial_model(self._pyd_model)
+        last: Any = None
+        for chunk in self._chunks:
+            self._buffer.append(chunk)
+            data = parse_partial_json(self.text)
+            if data is None or not isinstance(data, dict):
+                continue
+            try:
+                partial = partial_cls.model_validate(data)
+            except _PydanticValidationError:
+                continue
+            dumped = partial.model_dump()
+            if dumped != last:
+                last = dumped
+                yield partial
+        self._result = _parse_and_validate("".join(self._buffer), self._pyd_model)
+        self._done = True
+
     @property
     def text(self) -> str:
         """これまでに受信したテキスト全体。"""
@@ -244,7 +279,7 @@ def ask_stream(prompt: str, *, output_model: Type[Any] | None = None) -> Streame
     増分テキストを逐次受け取りつつ、完了後に ``result()`` で検証済みモデルを得る。
     ストリーミングでは自己修復リトライは行わない (検証は完了時に1回)。
     """
-    pyd_model = _resolve_model(output_model)
+    pyd_model, _is_list = _resolve_model(output_model)
     llm = _get_llm_instance()
     schema = pyd_model.model_json_schema()
     messages: List[Dict[str, str]] = [

--- a/dariko/partial.py
+++ b/dariko/partial.py
@@ -1,0 +1,80 @@
+"""ストリーミング中の不完全な JSON を逐次パースするためのユーティリティ。
+
+部分的に届いた JSON 文字列を「閉じられる範囲で」補完してパースし、
+全フィールドを Optional 化した「部分モデル」へ検証する。
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Any, Optional, Type
+
+from pydantic import BaseModel, create_model
+
+
+def _balance(prefix: str) -> Optional[str]:
+    """JSON のプレフィックスを、開いた文字列・括弧を閉じて parse 可能な形にする。
+
+    括弧の対応が壊れている (閉じ過ぎ) 場合は ``None`` を返す。
+    """
+    in_str = False
+    esc = False
+    stack: list[str] = []
+    for ch in prefix:
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+        else:
+            if ch == '"':
+                in_str = True
+            elif ch == "{":
+                stack.append("}")
+            elif ch == "[":
+                stack.append("]")
+            elif ch in "}]":
+                if not stack:
+                    return None
+                stack.pop()
+    out = prefix
+    if in_str:
+        out += '"'
+    out += "".join(reversed(stack))
+    return out
+
+
+def parse_partial_json(buffer: str) -> Optional[Any]:
+    """部分的な JSON 文字列から、解釈可能な最大のオブジェクトを返す。
+
+    末尾の不完全なトークン (途中のキーや値) を切り詰めながら、最初に
+    parse できたものを返す。何も解釈できなければ ``None``。
+    """
+    s = buffer.strip()
+    if not s:
+        return None
+    # 長いプレフィックスから順に、閉じて parse できるものを探す
+    for end in range(len(s), 0, -1):
+        balanced = _balance(s[:end])
+        if balanced is None:
+            continue
+        try:
+            return json.loads(balanced)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+@lru_cache(maxsize=128)
+def build_partial_model(model: Type[BaseModel]) -> Type[BaseModel]:
+    """全フィールドを Optional (既定値 None) にした部分モデルを生成する。
+
+    ストリーミング途中の「まだ揃っていない」データを検証するために使う。
+    """
+    fields: dict[str, Any] = {
+        name: (Optional[field.annotation], None) for name, field in model.model_fields.items()
+    }
+    return create_model(f"Partial{model.__name__}", **fields)

--- a/tests/test_core/test_list_output.py
+++ b/tests/test_core/test_list_output.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+from dariko import ask, set_config
+from tests.conftest import Person
+
+
+def _mock_list_response(*args, **kwargs):
+    class MockResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '[{"name": "a", "age": 1, "dummy": false},'
+                                ' {"name": "b", "age": 2, "dummy": true}]'
+                            )
+                        }
+                    }
+                ]
+            }
+
+    return MockResponse()
+
+
+@patch("dariko.models.gpt.requests.post", side_effect=_mock_list_response)
+def test_ask_list_model(mock_post):
+    """output_model=list[Person] でリストとして検証される。"""
+    set_config(model="gpt-4o-mini", llm_key="test_key")
+    result = ask("test", output_model=list[Person])
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(r, Person) for r in result)
+    assert result[0].name == "a"
+    assert result[1].dummy is True

--- a/tests/test_core/test_partial.py
+++ b/tests/test_core/test_partial.py
@@ -1,0 +1,28 @@
+from dariko.partial import build_partial_model, parse_partial_json
+from tests.conftest import Person
+
+
+def test_parse_partial_json_progressive():
+    """途中までの JSON から解釈可能な最大オブジェクトを返す。"""
+    assert parse_partial_json('{"name": "test"') == {"name": "test"}
+    assert parse_partial_json('{"name": "test", "age":') == {"name": "test"}
+    assert parse_partial_json('{"name": "te') == {"name": "te"}
+    assert parse_partial_json('{"name": "test", "age": 20, "dummy": true}') == {
+        "name": "test",
+        "age": 20,
+        "dummy": True,
+    }
+
+
+def test_parse_partial_json_empty():
+    assert parse_partial_json("") is None
+    assert parse_partial_json("   ") is None
+
+
+def test_build_partial_model_all_optional():
+    """部分モデルは全フィールドが省略可能。"""
+    partial_cls = build_partial_model(Person)
+    obj = partial_cls.model_validate({"name": "x"})  # age / dummy 無しでも通る
+    assert obj.name == "x"
+    assert obj.age is None
+    assert obj.dummy is None

--- a/tests/test_core/test_stream.py
+++ b/tests/test_core/test_stream.py
@@ -58,6 +58,24 @@ def test_ask_stream_yields_and_validates():
     assert result.dummy is True
 
 
+def test_ask_stream_partials():
+    """partials() が部分モデルを progressively yield し、完了後に検証済みモデルを返す。"""
+    set_config(model="gpt-4o-mini", llm_key="test_key")
+    parts = ['{"name": "test"', ', "age": 20', ', "dummy": true}']
+
+    with patch("dariko.models.gpt.requests.post", return_value=_StreamResp(_gpt_sse(parts))):
+        stream = ask_stream("test", output_model=Person)
+        snapshots = [p.model_dump() for p in stream.partials()]
+        result = stream.result()
+
+    # name だけ -> name+age -> 全部、と段階的に埋まる
+    assert {"name": "test", "age": None, "dummy": None} in snapshots
+    assert {"name": "test", "age": 20, "dummy": None} in snapshots
+    assert snapshots[-1] == {"name": "test", "age": 20, "dummy": True}
+    assert isinstance(result, Person)
+    assert result.dummy is True
+
+
 def test_result_before_consume_raises():
     """消費前に result() を呼ぶとエラー。"""
     set_config(model="gpt-4o-mini", llm_key="test_key")


### PR DESCRIPTION
## Summary
- 部分オブジェクトのストリーミング `StreamedResponse.partials()` を追加（dariko の独自軸を強化）
- `list[Model]` 出力（`output_model=list[Person]`）に対応

## 変更内容
- **部分ストリーミング**: ストリーミング中の不完全な JSON を逐次パースし、全フィールド Optional の「部分モデル」を progressively yield。UI のプログレッシブ表示向け
- **部分 JSON パーサ** (`dariko.partial`): 開いた文字列・括弧を補完し、解釈可能な最大オブジェクトを返す。`build_partial_model` で全フィールド Optional 化
- **リスト出力**: `output_model=list[Person]` を検出し `list[Person]` として検証（ask / ask_batch / aask / aask_batch）

## 検証
- `python -m pytest` → 19 passed, 1 skipped
- ruff（F/E/W/I/B）パス
- `import dariko` で torch 未ロードを維持

破壊的変更なし → semantic-release はマイナー（v3.2.0）想定。